### PR TITLE
Logrus was moved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # Created by .ignore support plugin (hsz.mobi)
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
@@ -47,7 +46,7 @@ crashlytics-build.properties
 fabric.properties
 vendor/
 vault-gitlab-link
-=======
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a
@@ -72,4 +71,3 @@ _testmain.go
 *.exe
 *.test
 *.prof
->>>>>>> b52e914a1bef4a8f65e0962d2dd9b36bdd88367a

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Vault GitLab link
+
+## Build
+
+```
+$ glide install -v
+$ go build
+```
+
+## Configuration
+
+See [config-example.yml](config-example.yml).

--- a/glide.lock
+++ b/glide.lock
@@ -40,7 +40,7 @@ imports:
   version: b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4
 - name: github.com/sethgrid/pester
   version: 2c5fb962da6113d0968907fd81dba3ca35151d1c
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/xanzy/go-gitlab
   version: 189ae0a841d3d0b3999ee2ae5d53203c3809a2bc

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/SageAxcess/untitled
+package: github.com/nebtex/vault-gitlab-link
 import:
 - package: github.com/hashicorp/vault
   version: ^0.7.0-beta1


### PR DESCRIPTION
Logrus was moved from github.com/sirupsen/logrus to github.com/sirupsen/logrus repository.

```
$ glide install -v
...
[INFO]	--> Fetching updates for github.com/Sirupsen/logrus.
[ERROR]	Update failed for github.com/Sirupsen/logrus: The Remote does not match the VCS endpoint
[ERROR]	Failed to install: The Remote does not match the VCS endpoint
```
